### PR TITLE
Basic option parsing and option to set error code returned form print_error

### DIFF
--- a/commands/backup.php
+++ b/commands/backup.php
@@ -3,10 +3,17 @@
 $subcommands = [
     "create" => function(){
         global $application;
-        global $argv;
         global $workingDir;
-
+        global $argc;
+        global $argv;
+        
+        $argParser=create_argParser();
+        add_parser_option($argParser,"f");
+        parse_args($argParser,$argc,$argv);
         $force = false;
+        if(option_is_set($argParser,"f")){
+            $force = true;
+        }
 
         $serviceLocator = $application->getServiceManager();
         $settings = $serviceLocator->get('ApplicationConfig')['connection'];

--- a/commands/config.php
+++ b/commands/config.php
@@ -3,8 +3,17 @@ $subcommands = [
     "list" => function(){
         global $application;
         global $argv;
+        global $argc;
         $format = 'list';
         $mode = 'human';
+        
+        $argParser=create_argParser();
+        add_parser_option($argParser,"j");
+        parse_args($argParser,$argc,$argv);
+        
+        if(option_is_set($argParser,"j")){
+            $mode='raw';
+        }
         $serviceLocator = $application->getServiceManager();
 
         $setingsType = $argv[3] ?? 'global';

--- a/commands/core.php
+++ b/commands/core.php
@@ -12,8 +12,16 @@ $subcommands = [
     },
     "upgrade" => function(){
         global $application;
+        global $argc;
         global $argv;
-        $force = ($argv[3]=='-f'||$argv[3]=='--force');
+        
+        $argParser=create_argParser();
+        add_parser_option($argParser,"f");
+        parse_args($argParser,$argc,$argv);
+        $force = false;
+        if(option_is_set($argParser,"f")){
+            $force = true;
+        }
         $serviceLocator = $application->getServiceManager();
         $settings = $serviceLocator->get('Omeka\Settings');
         $currentVersion = $settings->get('version');
@@ -22,8 +30,9 @@ $subcommands = [
         echo("Current version: $currentVersion\n");
         echo("Latest version: $latestVersion\n");
 
-        if(($latestVersion==$currentVersion)&&(!$force)){
-            print_error("Omeka S core seems up to date");
+        if(($latestVersion==$currentVersion)){
+            
+            print_error("Omeka S core seems up to date",true,0);
         }
 
         if(!$force){

--- a/commands/db.php
+++ b/commands/db.php
@@ -3,10 +3,17 @@
 $subcommands = [
     "dump" => function(){
         global $application;
+        global $argc;
         global $argv;
-        global $workingDir;
-
+        
+        $argParser=create_argParser();
+        add_parser_option($argParser,"f");
+        parse_args($argParser,$argc,$argv);
         $force = false;
+        if(option_is_set($argParser,"f")){
+            $force = true;
+        }
+        global $workingDir;
 
         $serviceLocator = $application->getServiceManager();
         $settings = $serviceLocator->get('ApplicationConfig')['connection'];

--- a/commands/info.php
+++ b/commands/info.php
@@ -3,8 +3,17 @@
 $subcommands = [
     "system" => function(){
         global $application;
+        global $argc;
         global $argv;
-        $format = 'table';
+        $format='list';
+        
+        $argParser=create_argParser();
+        add_parser_option($argParser,"j");
+        parse_args($argParser,$argc,$argv);
+        
+        if(option_is_set($argParser,"j")){
+            $format='json';
+        }
         
         $serviceLocator = $application->getServiceManager();
         $controller = new Omeka\Controller\Admin\SystemInfoController(
@@ -16,15 +25,21 @@ $subcommands = [
         $model = $controller->browseAction();
         $info = $model->getVariable('info');
 
-
-
-        // output($humanInfo, $format);
-        output($info, 'list');
+        output($info, $format);
     },
     "db" => function(){
         global $application;
+        global $argc;
         global $argv;
-        $format = 'list';
+        $format='list';
+        
+        $argParser=create_argParser();
+        add_parser_option($argParser,"j");
+        parse_args($argParser,$argc,$argv);
+        
+        if(option_is_set($argParser,"j")){
+            $format='json';
+        }
         
         $serviceLocator = $application->getServiceManager();
         

--- a/commands/module.php
+++ b/commands/module.php
@@ -386,7 +386,8 @@ $subcommands = [
         global $argv;
         $module_name = $argv[3];
         $module = get_local_module($module_name);
-
+        $die=true;
+        $no_error_code=0;
         elevate_privileges();
         
         if(!$module){
@@ -401,7 +402,7 @@ $subcommands = [
             module_install($module);
         }
         elseif(($module->getState()=='active')){
-            print_error('The module seems to be already active');
+            print_error('The module seems to be already active',$die,$no_error_code);
         }
         elseif(($module->getState()!='not_installed')&&($module->getState()!='not_active')){
             print_error('The module cannot be installed because its status is: '.$module->getState());
@@ -416,12 +417,13 @@ $subcommands = [
         $module = get_local_module($module_name);
 
         elevate_privileges();
-        
+        $die=true;
+        $no_error_code=0;
         if(!$module){
-            print_error("Module not found");
+            print_error("Module not found",$die,$no_error_code);
         }
         elseif($module->getState()!='active'){
-            print_error('The module does not seem to be active');
+            print_error('The module does not seem to be active',$die,$no_error_code);
         }else{
             // Disable the module
             module_disable($module);

--- a/commands/module.php
+++ b/commands/module.php
@@ -89,7 +89,7 @@ function module_update($module){
         throw new Exception("Could not perform database update for the module: \n" . $e->getMessage());
     }
 }
-function module_delete($module){
+function module_delete($module,$force){
     global $application;
     $services = $application->getServiceManager();
     $moduleManager = $services->get('Omeka\ModuleManager');
@@ -107,6 +107,9 @@ function module_delete($module){
                 system("rm -rf ".escapeshellarg($path));
             }
 
+        }
+        else{
+            system("rm -rf ".escapeshellarg($path));
         }
     } catch (Exception $e) {
         print_error("Could not delete module: \n" . $e->getMessage());
@@ -314,7 +317,7 @@ $subcommands = [
                 }
             }
             // Delete
-            module_delete($module);
+            module_delete($module,$force);
         }
     },
     "update" => function(){

--- a/commands/module.php
+++ b/commands/module.php
@@ -432,7 +432,16 @@ $subcommands = [
     "status" => function(){
         global $application;
         global $argv;
+        global $argc;
         $format = 'table';
+        
+        $argParser=create_argParser();
+        add_parser_option($argParser,"j");
+        parse_args($argParser,$argc,$argv);
+        
+        if(option_is_set($argParser,"j")){
+            $format='json';
+        }
         $services = $application->getServiceManager();
         $omekaModules = $services->get('Omeka\ModuleManager');
         $modules = $omekaModules->getModules();
@@ -451,8 +460,7 @@ $subcommands = [
                 'isConfigurable' => $module->isConfigurable(),
             ]], $format);
         }else{
-            echo("Module {$argv[3]} not found\n");
-            exit(1);
+            print_error("Module {$argv[3]} not found\n");
         }
         
     },

--- a/commands/module.php
+++ b/commands/module.php
@@ -220,6 +220,8 @@ $subcommands = [
 
         elevate_privileges();
         echo $api_modules;
+        $die=true;
+        $no_error_code=0;
         if(!$module){
             echo("Module not found. Trying to download it...");
             $download_url = $api_modules[$module]['versions'][$api_modules[$module]['latest_version']]['download_url'];
@@ -231,7 +233,7 @@ $subcommands = [
             }
         }
         elseif(($module->getState()=='active')||($module->getState()=='not_active')){
-            print_error('The module seems to be already installed');
+            print_error('The module seems to be already installed',$die,$no_error_code);
         }
         elseif($module->getState()!='not_installed'){
             print_error('The module cannot be installed because its status is: '.$module->getState());

--- a/commands/module.php
+++ b/commands/module.php
@@ -168,6 +168,8 @@ $subcommands = [
         global $argv;
         $module = $argv[3];
 
+        $die=true;
+        $no_error_code=0;
         global $argc;
         $argParser=create_argParser();
         add_parser_option($argParser,"f");
@@ -200,7 +202,8 @@ $subcommands = [
                 print_error(output($module_list, 'table', true));
             }else{
                 if(module_is_installed($module) && !$force){
-                    print_error('The module seems to be already downloaded. Use the flag -f in order to download it anyway.');
+                    print_error('The module seems to be already downloaded. Use the flag -f in order to download it anyway.',
+                        $die,$no_error_code);
                 }
                 if(empty($version_to_download))
                     $version_to_download = $api_modules[$module]['latest_version'];

--- a/commands/theme.php
+++ b/commands/theme.php
@@ -82,10 +82,23 @@ function theme_delete($theme){
     }
 }
 
+
+
 $subcommands = [
     "list" => function(){
         global $application;
+        global $argc;
+        global $argv;
         $mode = 'human';
+        
+        $argParser=create_argParser();
+        add_parser_option($argParser,"j");
+        parse_args($argParser,$argc,$argv);
+        
+        if(option_is_set($argParser,"j")){
+            $mode='raw';
+        }
+        
         $format = 'table';
         $services = $application->getServiceManager();
         $omekaThemes = $services->get('Omeka\Site\ThemeManager');

--- a/commands/theme.php
+++ b/commands/theme.php
@@ -222,6 +222,8 @@ $subcommands = [
         $theme_name = $argv[3];
         $theme = get_local_theme($theme_name);
 
+        $die=true;
+        $no_error_code=0;
         elevate_privileges();
 
         $api_theme = get_theme_list_from_api()[$theme->getId()];
@@ -232,7 +234,7 @@ $subcommands = [
 
         if($api_theme){
             if($theme->getIni()['version']==$api_theme['latest_version']){
-                print_error('The theme does not seem to have available updates');
+                print_error('The theme does not seem to have available updates',$die,$no_error_code);
             }else{
                 // Download latest version and upgrade the theme
                 theme_download($theme, $api_theme);

--- a/functions.php
+++ b/functions.php
@@ -270,9 +270,80 @@ function human_filesize($bytes, $decimals = 2) {
     $sz = 'BKMGTP';
     $factor = floor((strlen($bytes) - 1) / 3);
     return sprintf("%.{$decimals}f", $bytes / pow(1024, $factor)) . @$sz[$factor]. 'B';
-  }
-  
+}
+
 function get_omeka_latest_version(){
     $OMEKA_VERSION_API_URL = 'https://api.omeka.org/latest-version-s';
     return file_get_contents($OMEKA_VERSION_API_URL);
 }
+function report_arg_parse_error($ok,$msg){
+    if(!$ok){
+        
+        echo $msg."\n";
+        exit(1);
+    }
+}
+function create_argParser(){
+    $result=Array();
+    return $result;
+}
+function add_parser_option(&$argParser,$option){
+    
+    report_arg_parse_error(gettype($option)=="string","\"".$option."\"option must be a string");
+    report_arg_parse_error(strlen($option)==1,"option must be of length 1");
+    $argParser["allowedShortOptions"].=$option;
+}
+function parse_args(&$argParser,$argc,$argv){
+    
+    for ($i=0; $i<$argc;$i++){
+        
+        $argType="unknown";
+        
+        if($argv[$i][0]=="-"){
+            
+            if(strlen($argv[$i])>1){
+                
+                if($argv[$i][1]=="-"){
+                    
+                    //NOTE: long option
+                    report_arg_parse_error(false,"\"".$argv[$i]."\" is a long option which isn't supported");
+                }
+                else{
+                    
+                    //NOTE: short options
+                    $argType="short";
+                    for($j=1;$j<strlen($argv[$i]);$j++){
+                        
+                        report_arg_parse_error(str_contains($argParser["allowedShortOptions"],$argv[$i][$j]),
+                            "\"".$argv[$i][$j]."\" not in allowed options \"".$argParser["allowedShortOptions"]."\"");
+                        $argParser['setShortOptions'].=$argv[$i][$j];
+                    }
+                }
+            }
+        }
+        else{
+            
+            //NOTE: argument
+            $argType="argument";
+        }
+    }
+}
+function option_is_set($argParser,$option){
+    
+    report_arg_parse_error(gettype($option)=='string',"\"".$option."\" option must be a string");
+    
+    $result=false;
+    if(strlen($option)>1){
+        
+        //NOTE: long option
+        report_arg_parse_error(false,"\"".$option."\" is a long option which isn't supported");
+    }
+    else{
+        
+        //NOTE: short option
+        $result=str_contains($argParser["setShortOptions"],$option);
+    }
+    
+    return $result;
+}
+

--- a/functions.php
+++ b/functions.php
@@ -195,10 +195,10 @@ function get_theme_list_from_api(){
     return json_decode(file_get_contents($THEME_LIST_API_URL), true);
 }
 
-function print_error($message, $die = true){
+function print_error($message, $die = true,$error_code=1){
     fwrite(STDERR, $message."\n");
     if($die){
-        exit(1);
+        exit($error_code);
     }
 }
 
@@ -283,6 +283,8 @@ function report_arg_parse_error($ok,$msg){
         exit(1);
     }
 }
+
+
 function create_argParser(){
     $result=Array();
     return $result;

--- a/omeka-s-cli.php
+++ b/omeka-s-cli.php
@@ -5,7 +5,6 @@
 */
 require 'includes.php';
 
-
 if($argc<2){
     echo("No command specified. ");
     printHelp();


### PR DESCRIPTION
There are two main additions/changes:

1. added very basic option parsing that works with the command/sub-command framework, added -j and -f options to produce output in json format, and to omit confirmation requirements for various tasks. Both of these options improve the use of these tools in automation frameworks allow output to be more easily parsed by a machine and not requiring human confirmation before performing tasks.
2. added an optional parameter to print_error function, which specifies what the error code should be allowing in some cases an error message to be printed and for the program to exit normally. This is helpful for situations where the failure isn't really an issue. For example failing to install a module when a module is already installed.